### PR TITLE
Add --strict flag to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,3 +34,9 @@ if (cmd === "parse") {
   console.error("Unknown command:", cmd);
   process.exit(1);
 }
+
+// --strict flag support
+if (args.includes("--strict")) {
+  const { enableStrictMode } = require("./config/validator");
+  enableStrictMode();
+}


### PR DESCRIPTION
Adds a new `--strict` flag to the `parse` command that enables strict config validation. Rejects unknown fields.\n\nNo docs updated yet — will do in follow-up.